### PR TITLE
Fix overlapped type label on completed exercises

### DIFF
--- a/docs/gym.html
+++ b/docs/gym.html
@@ -71,6 +71,9 @@
             background: #f8f9fa;
             transform: scale(0.98);
         }
+        .exercise-card.completed .exercise-type {
+            display: none;
+        }
 
         .exercise-card.active {
             border-left-color: #28a745;


### PR DESCRIPTION
## Summary
- hide the exercise type label when an exercise is marked as completed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6864fc6f94c483279dc0cf779fdf4ec8